### PR TITLE
do not expose stack limit as GPR

### DIFF
--- a/eabi.md
+++ b/eabi.md
@@ -30,7 +30,7 @@ accepted, `x14` should be renamed as `a4`.
 | `x4` | `tp` | Thread pointer |  |  |
 | `x5` | `t1/al` | Temporary/alternate link register | * | |
 | `x6` | `s3` | Saved register |  | * |
-| `x7` | `s4/sl` | Saved register/stack limit |  | * |
+| `x7` | `s4` | Saved register |  | * |
 |||||
 | `x8` | `s0/fp` | Saved register/frame pointer |  | * |
 | `x9` | `s1` | Saved register |  | * |
@@ -91,7 +91,7 @@ More details on the register allocation in the
 | `x4` | `tp` | Thread pointer |  |  |
 | `x5` | `t1/al` | Temporary/alternate link register | * | |
 | `x6` | `s3` | Saved register |  | * |
-| `x7` | `s4/sl` | Saved register/stack limit |  | * |
+| `x7` | `s4` | Saved register |  | * |
 |||||
 | `x8` | `s0/fp` | Saved register/frame pointer |  | * |
 | `x9` | `s1` | Saved register |  | * |


### PR DESCRIPTION
rationale:

- Stack limit is not about to be frequently accessed by thread code nor it is available from raw C/C++.
- Reserving another general purpose register, increases register pressure especially in RV32E which currently have less available registers than armv7[M].
- Stack limit can be corrupted by code.
- Mapping another shadow register into GPRs and protecting it from corruption by thread code, will increase hardware complexity.
- Saving 2 cycles on push/pop in context switch is a sign of premature optimization of whole ABI for specific use case.
Assuming 50MHz clockrate and 1000Hz scheduler tickrate, those 2 cycles saved per context switch accounts for 4E-5% of total cycles saved. Of course, only if rest of the code is actually not starving from missing register.